### PR TITLE
fix(pwa): use relative paths for service worker, manifest & cache

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -47,7 +47,7 @@
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/sw.js')
+                navigator.serviceWorker.register('./sw.js')
                     .then(registration => {
                         console.log('ServiceWorker registration successful with scope: ', registration.scope);
                     })

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -2,13 +2,13 @@
   "name": "Tauron — Herd Intelligence",
   "short_name": "Tauron",
   "description": "GNN early-warning system for dairy herd disease detection",
-  "start_url": "/",
-  "display": "browser",
+  "start_url": ".",
+  "display": "standalone",
   "theme_color": "#2C1A0E",
   "background_color": "#F2EDE4",
   "icons": [
     {
-      "src": "/icon.svg",
+      "src": "./icon.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any maskable"

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,17 +1,17 @@
 const CACHE_NAME = 'tauron-v2';
 const ASSETS = [
-  '/',
-  '/index.html',
-  '/style.css',
-  '/app.js',
-  '/manifest.json',
-  '/icon.svg',
-  '/components/MorningAlertFeed.js',
-  '/components/HerdMap.js',
-  '/components/DataEntryLog.js',
-  '/components/SustainabilityImpact.js',
-  '/components/Homepage.js',
-  '/components/Layout.js'
+  './',
+  './index.html',
+  './style.css',
+  './app.js',
+  './manifest.json',
+  './icon.svg',
+  './components/MorningAlertFeed.js',
+  './components/HerdMap.js',
+  './components/DataEntryLog.js',
+  './components/SustainabilityImpact.js',
+  './components/Homepage.js',
+  './components/Layout.js'
 ];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
- index.html: register('./sw.js') instead of register('/sw.js')
- manifest.json: start_url '.' instead of '/', icon src './icon.svg', display 'standalone' (enables Add to Home Screen prompt)
- sw.js: all ASSETS use './' prefix instead of '/' for subdirectory compat